### PR TITLE
Addition of Backend for Import and Export CSV files for decks

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/postcss": "^4.2.1",
+        "papaparse": "^5.5.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.1"
@@ -71,7 +72,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1697,7 +1697,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1739,7 +1738,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1885,7 +1883,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2142,7 +2139,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3069,6 +3065,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3114,7 +3116,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3141,7 +3142,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3183,7 +3183,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3193,7 +3192,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3480,7 +3478,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3602,7 +3599,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.2.1",
+    "papaparse": "^5.5.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.1"

--- a/client/src/context/BackendAuthConnection.jsx
+++ b/client/src/context/BackendAuthConnection.jsx
@@ -6,30 +6,18 @@ export const Authenticator = ({ children }) => {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
 
-  // now loading, fetch
+  // now loading, fetch user data from cookie 
   useEffect(() => {
     const fetchProfile = async () => {
-      const AuthToken = localStorage.getItem('token');
-      // attempt to grab if previosuly saved, else break as logged out
-      if (!AuthToken) {
-        setLoading(false);
-        return;
-      }
-
       try {
-        // http call using the bearer token (very similar to postman testing)
-        const response = await fetch('/api/me', {
-          headers: {
-            'Authorization': `Bearer ${AuthToken}`
-          }
-        }
-      );
+        // http call automatically sends cookie to /api/me
+        const response = await fetch('/api/me');
         if (response.ok) {
           const userData = await response.json();
           setUser(userData); // save login state for user
         } else {
-          // post 24hrs? or wrong token altogether
-          localStorage.removeItem('token');
+          // not logged in
+          setUser(null);
         }
       } catch (error) {
         // *shrug* fail
@@ -59,8 +47,6 @@ export const Authenticator = ({ children }) => {
       const data = await response.json();
 
       if (response.ok) {
-        // only save the user token from before
-        localStorage.setItem('token', data.token); 
         // token saved -> user logged in
         setUser(data.user);
         return { 
@@ -114,9 +100,13 @@ export const Authenticator = ({ children }) => {
     }
   };
 
-  // logout user and remove stored token
-  const logout = () => {
-    localStorage.removeItem('token');
+  // logout user and ask to clear cookie
+  const logout = async () => {
+    try {
+      await fetch('/api/logout', { method: 'POST' });
+    } catch (err) {
+      console.error("Logout API Error:", err);
+    }
     setUser(null);
   };
 

--- a/client/src/lib/CSV_Import.js
+++ b/client/src/lib/CSV_Import.js
@@ -1,0 +1,78 @@
+import Papa from 'papaparse';
+
+/** parse csv to json then OVERWRITE current deck with cards.
+ *  add warning sign to users saying that it will overwrite the current deck 
+ *  add below for intellisense 
+ * @param {File} file - file to parse
+ * @param {string|number} deckId - deck id
+ * @returns {Promise<{success: boolean, message?: string, error?: string}>}
+ */
+export const importCardsFromCSV = async (file, deckId) => {
+  return new Promise((resolve) => {
+    Papa.parse(file, {
+      // no title header just term definition
+      header: false,
+      skipEmptyLines: true,
+      complete: async (results) => {
+        try {
+          const parsedData = results.data;
+          
+          // term definition -> front back
+          // array of strings [term, def]
+          const cards = parsedData.map(row => {
+            return {
+              front: row[0] ? row[0].trim() : '',
+              back: row[1] ? row[1].trim() : '',
+            };
+            // only use cards with front/back, or else throw error in server.js
+          }).filter(card => card.front && card.back); 
+
+          const token = localStorage.getItem('token');
+          if (!token) {
+            return resolve({ 
+              success: false, 
+              error: 'User is not authenticated' 
+            });
+          }
+
+          // call new endpoint route in server.js to import cards
+          const response = await fetch(`/api/decks/${deckId}/import`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Bearer ${token}`
+            },
+            body: JSON.stringify({ cards })
+          });
+
+          const data = await response.json();
+
+          if (response.ok) {
+            resolve({ 
+              success: true, 
+              message: data.message 
+            });
+          } else {
+            resolve({ 
+              success: false, 
+              error: data.error || 'Failed to import CSV' 
+            });
+          }
+        } catch (error) {
+          console.error("CSV Import API Error:", error);
+          resolve({ 
+            success: false, 
+            error: 'API error during import' 
+          });
+        }
+      },
+      error: (error) => {
+        console.error("PapaParse error:", error);
+        resolve({ 
+          success: false, 
+          error: 'Failed parse of CSV' 
+        });
+      }
+    });
+  });
+};

--- a/client/src/lib/CSV_Import.js
+++ b/client/src/lib/CSV_Import.js
@@ -27,20 +27,12 @@ export const importCardsFromCSV = async (file, deckId) => {
               // only use cards with front/back, or else throw error in server.js
           }).filter(card => card.front && card.back); 
 
-          const token = localStorage.getItem('token');
-          if (!token) {
-            return resolve({
-              success: false,
-              error: 'User is not authenticated' 
-            });
-          }
-
           // call new endpoint route in server.js to import cards
+          // no need for header, cookie is persistent
           const response = await fetch(`/api/decks/${deckId}/import`, {
             method: 'POST',
             headers: {
-              'Content-Type': 'application/json',
-              'Authorization': `Bearer ${token}`
+              'Content-Type': 'application/json'
             },
             body: JSON.stringify({ cards })
           });

--- a/client/src/lib/CSV_Import.js
+++ b/client/src/lib/CSV_Import.js
@@ -1,8 +1,8 @@
 import Papa from 'papaparse';
 
 /** parse csv to json then OVERWRITE current deck with cards.
- *  add warning sign to users saying that it will overwrite the current deck 
- *  add below for intellisense 
+ *  add warning sign to users saying that it will overwrite the current deck
+ *  add below for intellisense
  * @param {File} file - file to parse
  * @param {string|number} deckId - deck id
  * @returns {Promise<{success: boolean, message?: string, error?: string}>}
@@ -16,21 +16,21 @@ export const importCardsFromCSV = async (file, deckId) => {
       complete: async (results) => {
         try {
           const parsedData = results.data;
-          
+
           // term definition -> front back
           // array of strings [term, def]
           const cards = parsedData.map(row => {
-            return {
+              return {
               front: row[0] ? row[0].trim() : '',
               back: row[1] ? row[1].trim() : '',
-            };
-            // only use cards with front/back, or else throw error in server.js
+              };
+              // only use cards with front/back, or else throw error in server.js
           }).filter(card => card.front && card.back); 
 
           const token = localStorage.getItem('token');
           if (!token) {
-            return resolve({ 
-              success: false, 
+            return resolve({
+              success: false,
               error: 'User is not authenticated' 
             });
           }
@@ -48,31 +48,69 @@ export const importCardsFromCSV = async (file, deckId) => {
           const data = await response.json();
 
           if (response.ok) {
-            resolve({ 
-              success: true, 
+            resolve({
+              success: true,
               message: data.message 
             });
           } else {
-            resolve({ 
-              success: false, 
+            resolve({
+              success: false,
               error: data.error || 'Failed to import CSV' 
             });
           }
         } catch (error) {
           console.error("CSV Import API Error:", error);
-          resolve({ 
-            success: false, 
+          resolve({
+            success: false,
             error: 'API error during import' 
           });
         }
       },
       error: (error) => {
         console.error("PapaParse error:", error);
-        resolve({ 
-          success: false, 
+        resolve({
+          success: false,
           error: 'Failed parse of CSV' 
         });
       }
     });
   });
+};
+
+/**
+ * export back from online only deck -> csv saved on device
+ * @param {Array<{front: string, back: string}>} cards - array of cards
+ * @param {string} deckTitle - name of the downloaded file
+ */
+export const exportCardsToCSV = (cards, deckTitle = "Deck") => {
+  if (!cards || cards.length === 0) {
+    console.warn("No cards to export.");
+    return false;
+  }
+  // must be set back to an array of strings again or else a header row will be made (we want same as import format)
+  const dataToExport = cards.map((card) => [card.front, card.back]);
+  
+  // thank u unparse
+  const csvString = Papa.unparse(dataToExport);
+
+  // decided on using blob downloads to create file than fs as it doesn't require file to be saved on backend
+  // basic blob stuff: https://dev.to/nombrekeff/download-file-from-blob-21ho
+  const blob = new Blob([csvString], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+
+  // connect link to blob
+  const link = document.createElement("a");
+  link.href = url;
+
+  // regex docs: https://stackoverflow.com/questions/11794144/regular-expression-for-valid-filename
+  const fileName = `${deckTitle.replace(/[\s/\\:]+/g, "_")}_StudyStrike.csv`;
+  // force a click to be download not a navigation to it
+  link.setAttribute("download", fileName);
+
+  // create the TEMPORARY LINK, force user to click, then remove it again
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  return true;
 };

--- a/client/src/src/diffPages/Dashboard.jsx
+++ b/client/src/src/diffPages/Dashboard.jsx
@@ -76,8 +76,6 @@ export default function Dashboard() {
   const [editDesc, setEditDesc] = useState("");
   const [saving, setSaving] = useState(false);
 
-  const token = localStorage.getItem("token");
-
   useEffect(() => {
     fetchDecks();
   }, []);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "bcryptjs": "^3.0.3",
+        "cookie-parser": "^1.4.7",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
         "jsonwebtoken": "^9.0.3",
@@ -227,6 +228,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
@@ -950,7 +970,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
   "type": "commonjs",
   "dependencies": {
     "bcryptjs": "^3.0.3",
+    "cookie-parser": "^1.4.7",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.3",

--- a/server/server.js
+++ b/server/server.js
@@ -3,8 +3,11 @@ const express = require('express'); //express.js thru node for web comm
 const pool = require('./db');  //imports created postgres pool from db.js
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
+// now using cookies instead of local storage bcs discussion on friday extremely unsecure
+const cookieParser = require('cookie-parser');
 const app = express();  // creates new express app
 app.use(express.json());
+app.use(cookieParser());
 //default for localhost 3000
 const port = 3000;
 
@@ -152,9 +155,9 @@ app.get('/api/columns/:table', async (req, res) => {
 const JWT_SECRET = process.env.JWT_SECRET;
 
 const authenticateToken = (req, res, next) => {
-  // grab header and the split it to only get the second part (token stored)
-  const authHeader = req.headers['authorization'];
-  const token = authHeader && authHeader.split(' ')[1];
+  // get token securely from cookie
+  // used instead of header as cookie sent over http
+  const token = req.cookies.token;
   
   // no token
   if (!token) {
@@ -217,11 +220,30 @@ app.post('/api/login', async (req, res) => {
     }
     // create jwt token by signing it, 24hr expiry
     const token = jwt.sign({ id: user.id, role: user.role, email: user.email }, JWT_SECRET, { expiresIn: '24h' });
-    res.json({ message: 'Login successful', token, user: { id: user.id, email: user.email, role: user.role, name: user.name } });
+    
+    // token now rests in http cookie
+    res.cookie('token', token, { 
+      httpOnly: true, 
+      // uses the secure flag http(S) if hosting it normally (not on localhost)
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 24 * 60 * 60 * 1000, // 24 hours cookie lifetime
+      // cookie setting to prevent CSRF
+      // https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html
+      sameSite: 'lax'
+    });
+
+    // dont need to include token in response, lives in cookie
+    res.json({ message: 'Login successful', user: { id: user.id, email: user.email, role: user.role, name: user.name } });
     } catch (err) {
       console.error('Login error FULL:', err.message, err.stack);
       res.status(500).json({ error: 'Failed to login' });
     }
+});
+
+// logout to destroy cookie
+app.post('/api/logout', (req, res) => {
+  res.clearCookie('token');
+  res.json({ message: 'Logout successful' });
 });
 
 // user profile info, GET

--- a/server/server.js
+++ b/server/server.js
@@ -460,6 +460,68 @@ app.delete('/api/cards/:cardId', async (req, res) => {
   }
 });
 
+app.post('/api/decks/:deckId/import', authenticateToken, async (req, res) => {
+  try {
+    const { deckId } = req.params;
+    const { cards } = req.body;
+    // imported array
+    if (!cards || !Array.isArray(cards)) {
+      return res.status(400).json({ 
+        error: 'cards array is required' 
+      });
+    }
+
+    // check ownership to not delete other users decks during import
+    const deckResult = await pool.query(
+      `SELECT * FROM decks WHERE id = $1 AND user_id = $2`,
+      [deckId, req.user.id]
+    );
+
+    if (deckResult.rows.length === 0) {
+      return res.status(404).json({ 
+        error: 'Deck not found or not owned' 
+      });
+    }
+
+    await pool.query('BEGIN');
+
+    // delete existing cards
+    await pool.query(
+      `DELETE FROM flashcards WHERE deck_id = $1`,
+      [deckId]
+    );
+
+    // insert new ones
+    for (const card of cards) {
+      if (!card.front || !card.back) {
+        throw new Error('Invalid card payload. Missing term or definition.');
+      }
+      await pool.query(
+        `
+        INSERT INTO flashcards (deck_id, front, back)
+        VALUES ($1, $2, $3)
+        `,
+        [deckId, card.front, card.back]
+      );
+    }
+    
+    // update deck timestamp
+    await pool.query(
+      `UPDATE decks SET updated_at = CURRENT_TIMESTAMP WHERE id = $1`,
+      [deckId]
+    );
+    await pool.query('COMMIT');
+
+    res.json({ success: true, message: 'Deck imported successfully' });
+  } catch (err) {
+    await pool.query('ROLLBACK');
+    console.error('Import deck error:', err);
+    res.status(500).json({ 
+      error: err.message === 'Invalid card payload. Missing front or back.' ? err.message : 'Failed to import deck' 
+    });
+  }
+});
+
 app.post('/api/decks/:id/duplicate', async (req, res) => {
   try {
     const { id } = req.params;


### PR DESCRIPTION
Using papaparse to parse the import of CSV files:
- backend features take in file upload of a csv with NO HEADER for term and def
- Parses it into a JSON
- calls api route to add these new cards **OVERWRITING** the old cards in the deck

Export created deck as a csv:
- used blob method since uploaded csv->json parse is already done client side
- creates link with file, forces user click, removes link afterwards

Both import and export verify authtoken to ensure ownership of deck for modification of cards

Issue #13 fully completed 