### PR TITLE
Add study time tracking and leaderboard integration

### DIFF
--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.14" />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="5fc00f28-15b4-48f9-b8ce-844271a67c38" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/server/server.js" beforeDir="false" afterPath="$PROJECT_DIR$/server/server.js" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="CopilotPersistence">
+    <persistenceIdMap>
+      <entry key="_/Users/parth/Documents/GitHub/StudyStrike" value="3AjT3Y8NHBBNJNMqS433Kpm288E" />
+    </persistenceIdMap>
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 3
+}</component>
+  <component name="ProjectId" id="3AjT3Y8NHBBNJNMqS433Kpm288E" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ASKED_SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "git-widget-placeholder": "Parth-Backend",
+    "settings.editor.selected.configurable": "com.jetbrains.python.configuration.PyActiveSdkModuleConfigurable"
+  }
+}]]></component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-python-sdk-ca5e2b39c7df-6e1f45a539f7-com.jetbrains.pycharm.pro.sharedIndexes.bundled-PY-253.29346.308" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="5fc00f28-15b4-48f9-b8ce-844271a67c38" name="Changes" comment="" />
+      <created>1773104781046</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1773104781046</updated>
+    </task>
+    <servers />
+  </component>
+  <component name="github-copilot-workspace">
+    <instructionFileLocations>
+      <option value=".github/instructions" />
+    </instructionFileLocations>
+    <promptFileLocations>
+      <option value=".github/prompts" />
+    </promptFileLocations>
+  </component>
+</project>

--- a/server/server.js
+++ b/server/server.js
@@ -145,6 +145,15 @@ app.get('/api/init-db', async (req, res) => {
   );
 `);
 
+await pool.query(`
+  CREATE TABLE IF NOT EXISTS study_sessions (
+    id SERIAL PRIMARY KEY,
+    deck_id INTEGER NOT NULL REFERENCES decks(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    duration_seconds INTEGER NOT NULL CHECK (duration_seconds > 0),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  );
+`);
 
     res.json({ success: true, message: 'Database tables created successfully.' });
   } catch (err) {
@@ -625,7 +634,7 @@ app.post('/api/decks/:deckId/import', authenticateToken, async (req, res) => {
     await pool.query('ROLLBACK');
     console.error('Import deck error:', err);
     res.status(500).json({
-      error: err.message === 'Invalid card payload. Missing front or back.' ? err.message : 'Failed to import deck'
+      error: err.message === 'Invalid card payload. Missing term or definition.' ? err.message : 'Failed to import deck'
     });
   }
 });
@@ -970,7 +979,14 @@ app.get('/api/decks/:deckId/leaderboard', authenticateToken, async (req, res) =>
           CAST(GREATEST(COALESCE(ROUND((8.0 / NULLIF(ma.moves, 0)) * 500) - (FLOOR(ma.time_elapsed_ms::numeric / 10000.0) * 10), 0), 0) AS INTEGER) AS points
         FROM minigame_attempts ma
         WHERE ma.deck_id = $1
-      ),
+
+        UNION ALL
+        SELECT
+            ss.user_id,
+            CAST(FLOOR(ss.duration_seconds / 60.0) * 5 AS INTEGER) AS points
+        FROM study_sessions ss
+        WHERE ss.deck_id = $1
+  ),
       user_totals AS (
         SELECT 
           ap.user_id,
@@ -1056,6 +1072,121 @@ app.post('/api/decks/:deckId/generate-quiz', authenticateToken, async (req, res)
   }
   res.status(201).json(quizDat);
 });
+
+app.post('/api/decks/:deckId/study-time', authenticateToken, async (req, res) => {
+  try {
+    const deckId = Number(req.params.deckId);
+    const { duration_seconds } = req.body;
+
+    if (!Number.isInteger(deckId)) {
+      return res.status(400).json({ error: 'Invalid deck id' });
+    }
+
+    if (!Number.isInteger(duration_seconds) || duration_seconds <= 0) {
+      return res.status(400).json({ error: 'duration_seconds must be a positive integer' });
+    }
+
+    const deckAccessResult = await pool.query(
+      `
+      SELECT d.id
+      FROM decks d
+      LEFT JOIN shared_deck_access sda ON d.id = sda.deck_id
+      WHERE d.id = $1
+        AND d.status = 'active'
+        AND (d.user_id = $2 OR sda.user_id = $2)
+      `,
+      [deckId, req.user.id]
+    );
+
+    if (deckAccessResult.rows.length === 0) {
+      return res.status(403).json({ error: 'No access to this deck' });
+    }
+
+    const result = await pool.query(
+      `
+      INSERT INTO study_sessions (deck_id, user_id, duration_seconds)
+      VALUES ($1, $2, $3)
+      RETURNING *;
+      `,
+      [deckId, req.user.id, duration_seconds]
+    );
+
+    res.status(201).json({
+      message: 'Study time recorded successfully',
+      study_session: result.rows[0]
+    });
+  } catch (err) {
+    console.error('Submit study time error:', err);
+    res.status(500).json({ error: 'Failed to record study time' });
+  }
+});
+
+app.get('/api/my-study-sessions', authenticateToken, async (req, res) => {
+  try {
+    const result = await pool.query(
+      `
+      SELECT ss.*, d.title AS deck_title
+      FROM study_sessions ss
+      JOIN decks d ON ss.deck_id = d.id
+      WHERE ss.user_id = $1
+      ORDER BY ss.created_at DESC;
+      `,
+      [req.user.id]
+    );
+
+    res.json(result.rows);
+  } catch (err) {
+    console.error('Get study sessions error:', err);
+    res.status(500).json({ error: 'Failed to fetch study sessions' });
+  }
+});
+
+app.get('/api/decks/:deckId/study-time', authenticateToken, async (req, res) => {
+  try {
+    const deckId = Number(req.params.deckId);
+
+    if (!Number.isInteger(deckId)) {
+      return res.status(400).json({ error: 'Invalid deck id' });
+    }
+
+    const deckAccessResult = await pool.query(
+      `
+      SELECT d.id
+      FROM decks d
+      LEFT JOIN shared_deck_access sda ON d.id = sda.deck_id
+      WHERE d.id = $1
+        AND d.status = 'active'
+        AND (d.user_id = $2 OR sda.user_id = $2)
+      `,
+      [deckId, req.user.id]
+    );
+
+    if (deckAccessResult.rows.length === 0) {
+      return res.status(403).json({ error: 'No access to this deck' });
+    }
+
+    const result = await pool.query(
+      `
+      SELECT
+        u.id AS user_id,
+        u.name AS user_name,
+        SUM(ss.duration_seconds) AS total_study_seconds
+      FROM study_sessions ss
+      JOIN users u ON ss.user_id = u.id
+      WHERE ss.deck_id = $1
+      GROUP BY u.id, u.name
+      ORDER BY total_study_seconds DESC;
+      `,
+      [deckId]
+    );
+
+    res.json(result.rows);
+  } catch (err) {
+    console.error('Get deck study time error:', err);
+    res.status(500).json({ error: 'Failed to fetch study time' });
+  }
+});
+
 //allows for express and server to wait for client requests on the selected port
 app.listen(port, () => {
   console.log(`StudyStrike running on http://localhost:${port}`);


### PR DESCRIPTION
Added backend study-time tracking with a new study_sessions table, plus routes to submit study time, fetch a user’s study sessions, and get deck study-time totals. Also updated the deck leaderboard to include study-time points, while keeping the earlier leaderboard fixes for deckId validation and stable ordering. Tested end to end: DB init, login, study-time submission, study-session retrieval, deck totals, and leaderboard scoring all worked.